### PR TITLE
add repoLister and baseUrl functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ ghrepos.getRef(authOptions, 'nodejs', 'io.js', 'heads/v1.x', function (err, refD
 })
 ```
 
-### repoLister(type)
+### createLister(type)
 
 Creates a function that lists different sub types related to the `'/repos'` api, e.g. list `'issues'`, `'pulls'` or `'releases'`. The function returned has the signature: `function list (auth, org, repo, options, callback)`.
 

--- a/README.md
+++ b/README.md
@@ -13,31 +13,52 @@ See also:
 * https://github.com/rvagg/ghteams
 * https://github.com/rvagg/ghauth
 
+## API
 
-## Example usage
+### list(auth[, org][, options], callback)
+
+List all repos for a user or organization. If `org` and `options` are omitted the current user is assumed.
+
+List all repos for user `'rvagg'`:
 
 ```js
 const ghrepos     = require('ghrepos')
     , authOptions = { user: 'rvagg', token: '24d5dee258c64aef38a66c0c5eca459c379901c2' }
 
-// list all repos for a user
 ghrepos.list(authOptions, 'rvagg', function (err, repolist) {
-  // Array of repos for user 'rvagg'
   console.log(reposlist)
 })
+```
 
-// get git ref data for a given ref string
-ghrepos.getRef(authOptions, 'iojs', 'io.js', 'heads/v1.x', function (err, refData) {
-  // data containing ref information including sha and github url
-  console.log(refData)
-})
+### listRefs(auth, org, repo[, options], callback)
 
-// get git ref data for all refs in a repo
-ghrepos.listRefs(authOptions, 'iojs', 'io.js', function (err, refData) {
+Get git ref data for all refs in a repo.
+
+Get all ref data for `nodejs/io.js` repo:
+
+```js
+ghrepos.listRefs(authOptions, 'nodejs', 'io.js', function (err, refData) {
   // data containing ref information including sha and github url
   console.log(refData)
 })
 ```
+
+### getRef(auth, org, repo, ref[, options], callback)
+
+Get git ref data for a particular ref string.
+
+Get git ref data for `v1.x` branch in `nodejs/io.js` repo:
+
+```js
+ghrepos.getRef(authOptions, 'nodejs', 'io.js', 'heads/v1.x', function (err, refData) {
+  // data containing ref information including sha and github url
+  console.log(refData)
+})
+```
+
+### repoLister(type)
+
+Creates a function that lists different sub types related to the `'/repos'` api, e.g. list `'issues'`, `'pulls'` or `'releases'`. The function returned has the signature: `function list (auth, org, repo, options, callback)`.
 
 _More methods coming .. as I need them or as you PR them in._
 

--- a/ghrepos.js
+++ b/ghrepos.js
@@ -48,7 +48,7 @@ function getRef (auth, org, repo, ref, options, callback) {
 }
 
 
-function repoLister (type) {
+function createLister (type) {
   return function list (auth, org, repo, options, callback) {
     if (typeof options == 'function') {
       callback = options
@@ -71,8 +71,8 @@ function baseUrl (org, repo) {
 }
 
 
-module.exports.list       = list
-module.exports.listRefs   = listRefs
-module.exports.getRef     = getRef
-module.exports.baseUrl    = baseUrl
-module.exports.repoLister = repoLister
+module.exports.list         = list
+module.exports.listRefs     = listRefs
+module.exports.getRef       = getRef
+module.exports.baseUrl      = baseUrl
+module.exports.createLister = createLister

--- a/ghrepos.js
+++ b/ghrepos.js
@@ -1,6 +1,8 @@
 const ghutils = require('ghutils')
+    , apiRoot = ghutils.apiRoot
 
-module.exports.list = function list (auth, org, options, callback) {
+
+function list (auth, org, options, callback) {
   if (typeof org == 'function') { // list for this user
     callback = org
     options = {}
@@ -10,7 +12,7 @@ module.exports.list = function list (auth, org, options, callback) {
     options  = {}
   }
 
-  var urlbase = 'https://api.github.com'
+  var urlbase = apiRoot
 
   if (org == null)
     urlbase += '/user/repos'
@@ -21,19 +23,18 @@ module.exports.list = function list (auth, org, options, callback) {
 }
 
 
-module.exports.listRefs = function listRefs (auth, org, repo, options, callback) {
+function listRefs (auth, org, repo, options, callback) {
   if (typeof options == 'function') { // no options
     callback = options
     options  = {}
   }
 
-  var urlbase = 'https://api.github.com/repos/' + org + '/' + repo + '/git/refs'
-
-  ghutils.lister(auth, urlbase, options, callback)
+  var url = refsBaseUrl(org, repo)
+  ghutils.lister(auth, url, options, callback)
 }
 
 
-module.exports.getRef = function get (auth, org, repo, ref, options, callback) {
+function getRef (auth, org, repo, ref, options, callback) {
   if (typeof options == 'function') {
     callback = options
     options  = {}
@@ -42,7 +43,36 @@ module.exports.getRef = function get (auth, org, repo, ref, options, callback) {
   // a valid ref but we're not using this format
   ref = ref.replace(/^refs\//, '')
 
-  var url = 'https://api.github.com/repos/' + org + '/' + repo + '/git/refs/' + ref
-
+  var url = refsBaseUrl(org, repo) + '/' + ref
   ghutils.ghget(auth, url, options, callback)
 }
+
+
+function repoLister (type) {
+  return function list (auth, org, repo, options, callback) {
+    if (typeof options == 'function') {
+      callback = options
+      options  = {}
+    }
+
+    var url = baseUrl(org, repo) + '/' + type
+    ghutils.lister(auth, url, options, callback)
+  }
+}
+
+
+function refsBaseUrl (org, repo) {
+  return baseUrl(org, repo) + '/git/refs'
+}
+
+
+function baseUrl (org, repo) {
+  return apiRoot + '/repos/' + org + '/' + repo
+}
+
+
+module.exports.list       = list
+module.exports.listRefs   = listRefs
+module.exports.getRef     = getRef
+module.exports.baseUrl    = baseUrl
+module.exports.repoLister = repoLister

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "author": "Rod Vagg <r@va.gg>",
   "license": "MIT",
   "dependencies": {
-    "ghutils": "~1.2.1"
+    "ghutils": "~2.0.0"
   },
   "devDependencies": {
     "faucet": "0.0.1",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "author": "Rod Vagg <r@va.gg>",
   "license": "MIT",
   "dependencies": {
-    "ghutils": "~2.0.0"
+    "ghutils": "~3.0.0"
   },
   "devDependencies": {
     "faucet": "0.0.1",

--- a/test.js
+++ b/test.js
@@ -165,3 +165,28 @@ test('test get ref data for a ref with refs/ prefix', function (t) {
     .on('close'  , ghutils.verifyClose(t))
 })
 
+
+test('test footype repo lister', function (t) {
+  t.plan(10)
+
+  var auth     = { user: 'authuser', token: 'authtoken' }
+    , org      = 'testorg'
+    , repo     = 'testrepo'
+    , testData = [
+          [ { test3: 'data3' }, { test4: 'data4' } ]
+        , []
+      ]
+    , lister   = ghrepos.repoLister('footype')
+    , server
+
+  server = ghutils.makeServer(testData)
+    .on('ready', function () {
+      lister(xtend(auth), org, repo, ghutils.verifyData(t, testData[0].concat(testData[1])))
+    })
+    .on('request', ghutils.verifyRequest(t, auth))
+    .on('get', ghutils.verifyUrl(t, [
+        'https://api.github.com/repos/' + org + '/' + repo + '/footype?page=1'
+      , 'https://api.github.com/repos/' + org + '/' + repo + '/footype?page=2'
+    ]))
+    .on('close'  , ghutils.verifyClose(t))
+})

--- a/test.js
+++ b/test.js
@@ -1,4 +1,4 @@
-const ghutils = require('ghutils/test')
+const ghutils = require('ghutils/test-util')
     , ghrepos = require('./')
     , test    = require('tape')
     , xtend   = require('xtend')
@@ -9,40 +9,50 @@ test('test list repos for org/user', function (t) {
 
   var auth     = { user: 'authuser', token: 'authtoken' }
     , org      = 'testorg'
-    , testData = [ [ { test1: 'data1' }, { test2: 'data2' } ], [] ]
-    , server
-
-  server = ghutils.makeServer(testData)
-    .on('ready', function () {
-      ghrepos.list(xtend(auth), org, ghutils.verifyData(t, testData[0]))
-    })
-    .on('request', ghutils.verifyRequest(t, auth))
-    .on('get', ghutils.verifyUrl(t, [
-        'https://api.github.com/users/testorg/repos?page=1'
-      , 'https://api.github.com/users/testorg/repos?page=2'
-    ]))
-    .on('close'  , ghutils.verifyClose(t))
-})
-
-
-test('test list repos for authed user', function (t) {
-  t.plan(10)
-
-  var auth     = { user: 'authuser', token: 'authtoken' }
     , testData = [
-          [ { test3: 'data3' }, { test4: 'data4' } ]
+          {
+              response : [ { test3: 'data3' }, { test4: 'data4' } ]
+            , headers  : { link: '<https://somenexturl>; rel="next"' }
+          }
         , []
       ]
     , server
 
   server = ghutils.makeServer(testData)
     .on('ready', function () {
-      ghrepos.list(xtend(auth), ghutils.verifyData(t, testData[0]))
+      var result = testData[0].response
+      ghrepos.list(xtend(auth), org, ghutils.verifyData(t, result))
     })
     .on('request', ghutils.verifyRequest(t, auth))
     .on('get', ghutils.verifyUrl(t, [
-        'https://api.github.com/user/repos?page=1'
-      , 'https://api.github.com/user/repos?page=2'
+        'https://api.github.com/users/testorg/repos'
+      , 'https://somenexturl'
+    ]))
+    .on('close'  , ghutils.verifyClose(t))
+})
+
+test('test list repos for authed user', function (t) {
+  t.plan(10)
+
+  var auth     = { user: 'authuser', token: 'authtoken' }
+    , testData = [
+          {
+              response : [ { test3: 'data3' }, { test4: 'data4' } ]
+            , headers  : { link: '<https://somenexturl>; rel="next"' }
+          }
+        , []
+      ]
+    , server
+
+  server = ghutils.makeServer(testData)
+    .on('ready', function () {
+      var result = testData[0].response
+      ghrepos.list(xtend(auth), ghutils.verifyData(t, result))
+    })
+    .on('request', ghutils.verifyRequest(t, auth))
+    .on('get', ghutils.verifyUrl(t, [
+        'https://api.github.com/user/repos'
+      , 'https://somenexturl'
     ]))
     .on('close'  , ghutils.verifyClose(t))
 })
@@ -53,21 +63,28 @@ test('test list repos for authed user with multi-page', function (t) {
 
   var auth     = { user: 'authuser', token: 'authtoken' }
     , testData = [
-          [ { test3: 'data3' }, { test4: 'data4' } ]
-        , [ { test5: 'data5' }, { test6: 'data6' } ]
+          {
+              response : [ { test3: 'data3' }, { test4: 'data4' } ]
+            , headers  : { link: '<https://somenexturl>; rel="next"' }
+          }
+        , {
+              response : [ { test5: 'data5' }, { test6: 'data6' } ]
+            , headers  : { link: '<https://somenexturl2>; rel="next"' }
+          }
         , []
       ]
     , server
 
   server = ghutils.makeServer(testData)
     .on('ready', function () {
-      ghrepos.list(xtend(auth), ghutils.verifyData(t, testData[0].concat(testData[1])))
+      var result = testData[0].response.concat(testData[1].response)
+      ghrepos.list(xtend(auth), ghutils.verifyData(t, result))
     })
     .on('request', ghutils.verifyRequest(t, auth))
     .on('get', ghutils.verifyUrl(t, [
-        'https://api.github.com/user/repos?page=1'
-      , 'https://api.github.com/user/repos?page=2'
-      , 'https://api.github.com/user/repos?page=3'
+        'https://api.github.com/user/repos'
+      , 'https://somenexturl'
+      , 'https://somenexturl2'
     ]))
     .on('close'  , ghutils.verifyClose(t))
 })
@@ -86,7 +103,7 @@ test('test list repos for authed user with no repos', function (t) {
     })
     .on('request', ghutils.verifyRequest(t, auth))
     .on('get', ghutils.verifyUrl(t, [
-        'https://api.github.com/user/repos?page=1'
+        'https://api.github.com/user/repos'
     ]))
     .on('close'  , ghutils.verifyClose(t))
 })
@@ -99,21 +116,28 @@ test('test get ref for a repo', function (t) {
     , org      = 'testorg'
     , repo     = 'testrepo'
     , testData = [
-          [ { test3: 'data3' }, { test4: 'data4' } ]
-        , [ { test5: 'data5' }, { test6: 'data6' } ]
+          {
+              response : [ { test3: 'data3' }, { test4: 'data4' } ]
+            , headers  : { link: '<https://somenexturl>; rel="next"' }
+          }
+        , {
+              response : [ { test5: 'data5' }, { test6: 'data6' } ]
+            , headers  : { link: '<https://somenexturl2>; rel="next"' }
+          }
         , []
       ]
     , server
 
   server = ghutils.makeServer(testData)
     .on('ready', function () {
-      ghrepos.listRefs(xtend(auth), org, repo, ghutils.verifyData(t, testData[0].concat(testData[1])))
+      var result = testData[0].response.concat(testData[1].response)
+      ghrepos.listRefs(xtend(auth), org, repo, ghutils.verifyData(t, result))
     })
     .on('request', ghutils.verifyRequest(t, auth))
     .on('get', ghutils.verifyUrl(t, [
-        'https://api.github.com/repos/' + org + '/' + repo + '/git/refs?page=1'
-      , 'https://api.github.com/repos/' + org + '/' + repo + '/git/refs?page=2'
-      , 'https://api.github.com/repos/' + org + '/' + repo + '/git/refs?page=3'
+        'https://api.github.com/repos/' + org + '/' + repo + '/git/refs'
+      , 'https://somenexturl'
+      , 'https://somenexturl2'
     ]))
     .on('close'  , ghutils.verifyClose(t))
 })
@@ -173,7 +197,10 @@ test('test footype repo lister', function (t) {
     , org      = 'testorg'
     , repo     = 'testrepo'
     , testData = [
-          [ { test3: 'data3' }, { test4: 'data4' } ]
+          {
+              response : [ { test3: 'data3' }, { test4: 'data4' } ]
+            , headers  : { link: '<https://somenexturl>; rel="next"' }
+          }
         , []
       ]
     , lister   = ghrepos.createLister('footype')
@@ -181,12 +208,13 @@ test('test footype repo lister', function (t) {
 
   server = ghutils.makeServer(testData)
     .on('ready', function () {
-      lister(xtend(auth), org, repo, ghutils.verifyData(t, testData[0].concat(testData[1])))
+      var result = testData[0].response
+      lister(xtend(auth), org, repo, ghutils.verifyData(t, result))
     })
     .on('request', ghutils.verifyRequest(t, auth))
     .on('get', ghutils.verifyUrl(t, [
-        'https://api.github.com/repos/' + org + '/' + repo + '/footype?page=1'
-      , 'https://api.github.com/repos/' + org + '/' + repo + '/footype?page=2'
+        'https://api.github.com/repos/' + org + '/' + repo + '/footype'
+      , 'https://somenexturl'
     ]))
     .on('close'  , ghutils.verifyClose(t))
 })

--- a/test.js
+++ b/test.js
@@ -176,7 +176,7 @@ test('test footype repo lister', function (t) {
           [ { test3: 'data3' }, { test4: 'data4' } ]
         , []
       ]
-    , lister   = ghrepos.repoLister('footype')
+    , lister   = ghrepos.createLister('footype')
     , server
 
   server = ghutils.makeServer(testData)


### PR DESCRIPTION
So here is a PR that explains my thinking a bit better. The idea is to have the `repoLister` function here and test that _once_. This would mean that [this test](https://github.com/rvagg/ghissues/blob/9f926075facaff648157b651511117dd281b9039/test.js#L9-L28) and [this](https://github.com/rvagg/ghpulls/blob/208296df8d582ae294b2eb275bb407e754325af1/test.js#L88-L107) are superfluous since they are essentially the same tests but with different types that would be covered by the test in this module.

This would also cover future functionality for e.g. the `'releases'` type as well.
