### PR TITLE
dependencies + tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,13 @@
 language: node_js
 node_js:
-  - "0.10"
+  - "5"
+  - "4"
+  - "3"
+  - "2"
+  - "1.8"
+  - "1.0"
   - "0.12"
+  - "0.10"
 branches:
   only:
     - master

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ghrepos
 
-<!-- [![Build Status](https://secure.travis-ci.org/rvagg/ghrepos.png)](http://travis-ci.org/rvagg/ghrepos) -->
+[![Build Status](https://secure.travis-ci.org/rvagg/ghrepos.png)](http://travis-ci.org/rvagg/ghrepos)
 
 **A node library to interact with the GitHub repos API**
 

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ const ghauth     = require('ghauth')
       }
 
 ghauth(authOptions, function (err, authData) {
-  ghrepos.list(authData, 'rvagg', function (err, list) {
+  ghrepos.listUser(authData, 'rvagg', function (err, list) {
     console.log('Repos for rvagg:')
     console.log(util.inspect(list.map(function (i) { return {
         name: i.name

--- a/ghrepos.js
+++ b/ghrepos.js
@@ -98,7 +98,6 @@ function baseUrl (org, repo) {
 }
 
 
-module.exports.list         = require('util').deprecate(listUser, 'ghrepos.list() is deprecated, use listUser() or listOrg() instead')
 module.exports.listUser     = listUser
 module.exports.listOrg      = listOrg
 module.exports.baseUrl      = baseUrl

--- a/package.json
+++ b/package.json
@@ -19,11 +19,11 @@
   "author": "Rod Vagg <r@va.gg>",
   "license": "MIT",
   "dependencies": {
-    "ghutils": "~3.0.0"
+    "ghutils": "~3.2.0"
   },
   "devDependencies": {
     "faucet": "0.0.1",
-    "tape": "~4.0.0",
+    "tape": "~4.2.2",
     "xtend": "~4.0.0"
   }
 }

--- a/test.js
+++ b/test.js
@@ -4,7 +4,34 @@ const ghutils = require('ghutils/test-util')
     , xtend   = require('xtend')
 
 
-test('test list repos for org/user', function (t) {
+test('test list repos for user', function (t) {
+  t.plan(10)
+
+  var auth     = { user: 'authuser', token: 'authtoken' }
+    , user     = 'testuser'
+    , testData = [
+          {
+              response : [ { test3: 'data3' }, { test4: 'data4' } ]
+            , headers  : { link: '<https://somenexturl>; rel="next"' }
+          }
+        , []
+      ]
+    , server
+
+  server = ghutils.makeServer(testData)
+    .on('ready', function () {
+      var result = testData[0].response
+      ghrepos.listUser(xtend(auth), user, ghutils.verifyData(t, result))
+    })
+    .on('request', ghutils.verifyRequest(t, auth))
+    .on('get', ghutils.verifyUrl(t, [
+        'https://api.github.com/users/testuser/repos?'
+      , 'https://somenexturl'
+    ]))
+    .on('close'  , ghutils.verifyClose(t))
+})
+
+test('test list repos for org', function (t) {
   t.plan(10)
 
   var auth     = { user: 'authuser', token: 'authtoken' }
@@ -21,11 +48,11 @@ test('test list repos for org/user', function (t) {
   server = ghutils.makeServer(testData)
     .on('ready', function () {
       var result = testData[0].response
-      ghrepos.list(xtend(auth), org, ghutils.verifyData(t, result))
+      ghrepos.listOrg(xtend(auth), org, ghutils.verifyData(t, result))
     })
     .on('request', ghutils.verifyRequest(t, auth))
     .on('get', ghutils.verifyUrl(t, [
-        'https://api.github.com/users/testorg/repos'
+        'https://api.github.com/orgs/testorg/repos?'
       , 'https://somenexturl'
     ]))
     .on('close'  , ghutils.verifyClose(t))
@@ -47,7 +74,7 @@ test('test list repos for authed user', function (t) {
   server = ghutils.makeServer(testData)
     .on('ready', function () {
       var result = testData[0].response
-      ghrepos.list(xtend(auth), ghutils.verifyData(t, result))
+      ghrepos.listUser(xtend(auth), ghutils.verifyData(t, result))
     })
     .on('request', ghutils.verifyRequest(t, auth))
     .on('get', ghutils.verifyUrl(t, [
@@ -78,7 +105,7 @@ test('test list repos for authed user with multi-page', function (t) {
   server = ghutils.makeServer(testData)
     .on('ready', function () {
       var result = testData[0].response.concat(testData[1].response)
-      ghrepos.list(xtend(auth), ghutils.verifyData(t, result))
+      ghrepos.listUser(xtend(auth), ghutils.verifyData(t, result))
     })
     .on('request', ghutils.verifyRequest(t, auth))
     .on('get', ghutils.verifyUrl(t, [
@@ -99,7 +126,7 @@ test('test list repos for authed user with no repos', function (t) {
 
   server = ghutils.makeServer(testData)
     .on('ready', function () {
-      ghrepos.list(xtend(auth), ghutils.verifyData(t, []))
+      ghrepos.listUser(xtend(auth), ghutils.verifyData(t, []))
     })
     .on('request', ghutils.verifyRequest(t, auth))
     .on('get', ghutils.verifyUrl(t, [


### PR DESCRIPTION
`?` is appended to `urlbase` in `list()` so tests needed an update + test on `listUser()` and `listOrg()` instead of `list()` which is deprecated.

@rvagg Mind flipping the switch on travis?

We could wipe `list()` from exports and bump major if you like.
